### PR TITLE
Remove hyphens from function names to make them more portable across shells

### DIFF
--- a/git-pair
+++ b/git-pair
@@ -2,31 +2,31 @@
 
 set -eu
 
-add-chum() {
+add_chum() {
 	if [ "$#" -lt 2 ]
 	then
-		print-usage
+		print_usage
 		exit 1
 	fi
 	git config --global "chums.$1" "$2"
 }
 
-list-chums() {
+list_chums() {
 	git config --global --get-regexp ^chums | cut -d. -f2-
 }
 
-set-active() {
+set_active() {
 	if [ "$#" -lt 1 ]
 	then
-		print-usage
+		print_usage
 		exit 1
 	fi
-	unset-active
+	unset_active
 	for chum in "$@"
 	do
 		if ! git config --global --get "chums.$chum" >/dev/null
 		then
-			unset-active
+			unset_active
 			echo Unknown person: $chum >/dev/stderr
 			exit 1
 		fi
@@ -34,11 +34,11 @@ set-active() {
 	done
 }
 
-unset-active() {
+unset_active() {
 	git config --local --remove-section active-chums 2>/dev/null || :
 }
 
-show-active() {
+show_active() {
 	if git config --local --get active-chums.i >/dev/null
 	then
 		for chum in `git config --local --get-all active-chums.i`
@@ -50,7 +50,7 @@ show-active() {
 	fi
 }
 
-print-coauthors() {
+print_coauthors() {
 	if ! git config --local --get active-chums.i >/dev/null
 	then
 		return
@@ -65,7 +65,7 @@ print-coauthors() {
 	IFS="$OLDIFS"
 }
 
-print-usage() {
+print_usage() {
 	printf "Usage:\n" >/dev/stderr
 	printf "  git pair { add | list | set | unset | show }\n" >/dev/stderr
 	printf "\n" >/dev/stderr
@@ -83,33 +83,33 @@ print-usage() {
 
 if [ "$#" -lt 1 ]
 then
-	print-usage
+	print_usage
 	exit 1
 fi
 
 case "$1" in
 	add)
 		shift
-		add-chum "$@"
+		add_chum "$@"
 		;;
 	list)
-		list-chums
+		list_chums
 		;;
 	set)
 		shift
-		set-active "$@"
+		set_active "$@"
 		;;
 	unset)
-		unset-active
+		unset_active
 		;;
 	show)
-		show-active
+		show_active
 		;;
 	print)
-		print-coauthors
+		print_coauthors
 		;;
 	*)
-		print-usage
+		print_usage
 		exit 1
 		;;
 esac


### PR DESCRIPTION
Not all shells support hyphens in function names. The hyphenated function names in the git-pair script was confirmed problematic in at least one version of zsh and bash. Please consider using this underscored version instead?

The POSIX standard does not explicitly name hyphens as a supported character in function names, even though it may be supported in some: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_235