### PR TITLE
Output the list of currently set co-authors on commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Maid Marion <marion@sherwood.org.uk>
 Friar Tuck <tuck@sherwood.org.uk>
 
 $ git commit -m 'Something informative'
+Committing with co-authors:
+ + Maid Marion <marion@sherwood.org.uk>
+ + Friar Tuck <tuck@sherwood.org.uk>
 [master d898f8d] Something informative
  1 file changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 foo

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -2,10 +2,26 @@
 
 set -eu
 
-COMMIT_MSG_FILE=$1
+append_coauthors() {
+    COMMIT_MSG_FILE=$1
 
-tmpfile="$COMMIT_MSG_FILE"-temp
-sed -e '/^Co-authored-by/d' $COMMIT_MSG_FILE >"$tmpfile"
-mv "$tmpfile" "$COMMIT_MSG_FILE"
+    tmpfile="$COMMIT_MSG_FILE"-temp
+    sed -e '/^Co-authored-by/d' $COMMIT_MSG_FILE >"$tmpfile"
+    mv "$tmpfile" "$COMMIT_MSG_FILE"
 
-git-pair print >>"$COMMIT_MSG_FILE"
+    git-pair print >>"$COMMIT_MSG_FILE"
+}
+
+print_coauthors() {
+    echo 'Committing with co-authors:'
+    OLDIFS="$IFS"
+    IFS=$'\n'
+    for AUTHOR in $(git-pair show)
+    do
+        printf " + $AUTHOR\n"
+    done
+    IFS="$OLDIFS"
+}
+
+append_coauthors $1
+print_coauthors


### PR DESCRIPTION
As a sanity check, print the list of currently set co-authors when issuing `git commit`. Also, do it in color!