### PR TITLE
skip script if message already contains a `co-authored-by` string

### DIFF
--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -5,11 +5,16 @@ set -eu
 append_coauthors() {
     COMMIT_MSG_FILE=$1
 
-    tmpfile="$COMMIT_MSG_FILE"-temp
-    sed -e '/^Co-authored-by/d' $COMMIT_MSG_FILE >"$tmpfile"
-    mv "$tmpfile" "$COMMIT_MSG_FILE"
+    if grep -q -i -e "Co-authored-by" "$COMMIT_MSG_FILE"; then
+      echo 'Co-author already supplied'
+    else
+      tmpfile="$COMMIT_MSG_FILE"-temp
+      sed -e '/^Co-authored-by/d' $COMMIT_MSG_FILE >"$tmpfile"
+      mv "$tmpfile" "$COMMIT_MSG_FILE"
 
-    git-pair print >>"$COMMIT_MSG_FILE"
+      git-pair print >>"$COMMIT_MSG_FILE"
+      print_coauthors
+    fi
 }
 
 print_coauthors() {
@@ -25,4 +30,3 @@ print_coauthors() {
 }
 
 append_coauthors $1
-print_coauthors


### PR DESCRIPTION
skip script if message already contains a `co-authored-by` string

This change tries to handle instances where a person provides a `co-authored-by` string using a different method.  Examples include:
* manually entering the tag on the command line
* using Github's desktop tool which provides a field in the GUI

It does not try to handle all edge-cases.  It simply looks if the `co-authored-by` string exists in the commit message, and skips the `git-pair` logic if it finds the tag already there.
